### PR TITLE
Specify a list of blocks to ignore

### DIFF
--- a/org-tracktable.el
+++ b/org-tracktable.el
@@ -78,6 +78,11 @@ inserting the table, to ensure consistency.  The default name is
 'tracktable'."
   :type 'string :group 'convenience)
 
+(defcustom org-tracktable-ignore-blocks nil
+  "A list of strings containing names of blocks to ignore.
+See `org-in-block-p' for more detail."
+  :type '(repeat string) :group 'convenience)
+
 (defun org-tracktable-tracktable-exists-p ()
   "Check if the 'tracktable' exists in buffer."
   (save-excursion
@@ -209,6 +214,9 @@ heading with the tag 'nowc' or 'noexport.'"
          ;; Ignore comments.
          ((org-at-comment-p)
           (forward-line))
+	 ;; Ignore blocks defined by user.
+	 ((org-in-block-p org-tracktable-ignore-blocks)
+	  (forward-line))
          ;; Ignore drawers.
          ((org-at-drawer-p)
 	  (progn (goto-char (match-end 0))


### PR DESCRIPTION
This allows the user to specify a list of blocks to ignore.
For example: (setq org-tracktable-ignore '("src" "comment")).
